### PR TITLE
Add SVG drop shadow to badge text

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ The width of the left side of the shield
 The width of the right side of the shield
 
 #### `nameBgColor` default _"#555"_
-The background color of the right side of the shield, this is commonly a neutral color, like gray.
+The background color of the right side of the shield, commonly a neutral color, like gray
 
 #### `valueBgColor` default _"#4b1"_
-The background color of the right side of the shield, this is commonly an indicator color, like red or green.
+The background color of the right side of the shield, commonly an indicator color, like red or green
 
 #### `name` default _""_
 The text on the left side of the shield
@@ -51,10 +51,10 @@ The text on the right side of the shield
 The font that should be used for badge text
 
 #### `fontSize` default _11_
-The size of the badge text; min: 8, max: 17
+The size of the badge text, values are bounded to min: 8, max: 17
 
 #### `radius` default _5_
-The size of the chamfer of the badge; min: 0, max: 10
+The size of the chamfer of the badge, values are bounded to min: 0, max: 10
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ The text on the right side of the shield
 The font that should be used for badge text
 
 #### `fontSize` default _11_
-The size of the badge text; values above 17 will be reset to 17 max
+The size of the badge text; min: 8, max: 17
+
+#### `radius` default _5_
+The size of the chamfer of the badge; min: 0, max: 10
+
 
 ## License
 

--- a/shield-pass.svg
+++ b/shield-pass.svg
@@ -1,13 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="20">
-    <mask id="a"><rect width="100" height="20" rx="5" ry="5" fill="#fff"/></mask>
-    <g mask="url(#a)">
+    <defs>
+        <filter id="drop-shadow">
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />
+        </filter>
+    </defs>
+    <mask id="round-rect"><rect width="100" height="20" rx="5" ry="5" fill="#fff"/></mask>
+    <g mask="url(#round-rect)">
         <path fill="#555" d="M0 0h60v20H0z"/>
         <path fill="#4b1" d="M60 0h60v20H60z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="11">
-        <text x="30" y="15" fill="#000">name</text>
-        <text x="80" y="15" fill="#000">value</text>
-        <text x="30" y="14">name</text>
-        <text x="80" y="14">value</text>
+        <text x="30" y="14" filter="url(#drop-shadow)">name</text>
+        <text x="80" y="14" filter="url(#drop-shadow)">value</text>
     </g>
 </svg>

--- a/shield-warn.svg
+++ b/shield-warn.svg
@@ -1,13 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="135" height="20">
-    <mask id="a"><rect width="135" height="20" rx="5" ry="5" fill="#fff"/></mask>
-    <g mask="url(#a)">
+    <defs>
+        <filter id="drop-shadow">
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />
+        </filter>
+    </defs>
+    <mask id="round-rect"><rect width="135" height="20" rx="5" ry="5" fill="#fff"/></mask>
+    <g mask="url(#round-rect)">
         <path fill="#111" d="M0 0h75v20H0z"/>
         <path fill="#C80" d="M75 0h60v20H75z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="11">
-        <text x="37.5" y="15" fill="#000">something</text>
-        <text x="105" y="15" fill="#000">warning</text>
-        <text x="37.5" y="14">something</text>
-        <text x="105" y="14">warning</text>
+        <text x="37.5" y="14" filter="url(#drop-shadow)">something</text>
+        <text x="105" y="14" filter="url(#drop-shadow)">warning</text>
     </g>
 </svg>

--- a/source/index.js
+++ b/source/index.js
@@ -5,16 +5,21 @@ var mustache = require( "mustache" );
 
 var shield = {
     svgData: '<svg xmlns="http://www.w3.org/2000/svg" width="{{width}}" height="20">\n\
-    <mask id="a"><rect width="{{width}}" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
-    <g mask="url(#a)">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="{{width}}" height="20" rx="{{radius}}" ry="{{radius}}" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
         <path fill="{{nameBgColor}}" d="M0 0h{{nameWidth}}v20H0z"/>\n\
         <path fill="{{valueBgColor}}" d="M{{nameWidth}} 0h60v20H{{nameWidth}}z"/>\n\
     </g>\n\
     <g fill="#fff" text-anchor="middle" font-family="{{fontFamily}}" font-size="{{fontSize}}">\n\
-        <text x="{{nameCenter}}" y="15" fill="#000">{{name}}</text>\n\
-        <text x="{{valueCenter}}" y="15" fill="#000">{{value}}</text>\n\
-        <text x="{{nameCenter}}" y="14">{{name}}</text>\n\
-        <text x="{{valueCenter}}" y="14">{{value}}</text>\n\
+        <text x="{{nameCenter}}" y="14" filter="url(#drop-shadow)">{{name}}</text>\n\
+        <text x="{{valueCenter}}" y="14" filter="url(#drop-shadow)">{{value}}</text>\n\
     </g>\n\
 </svg>'
 };
@@ -31,15 +36,14 @@ shield.getShield = function ( options, callback )
         name: "",
         value: "",
         fontFamily: "sans-serif",
-        fontSize: 11
+        fontSize: 11,
+        radius: 5
     };
 
     var config = xtend( {}, defaults, options );
 
-    if ( config.fontSize > 17 ) {
-        config.fontSize = 17;
-    }
-
+    config.fontSize = config.fontSize < 8 ? 8 : config.fontSize > 17 ? 17 : config.fontSize;
+    config.radius = config.radius < 0 ? 0 : config.radius > 10 ? 10 : config.radius;
     config.nameCenter = config.nameWidth / 2;
     config.valueCenter = config.nameWidth + config.valueWidth / 2;
     config.width = config.nameWidth + config.valueWidth;

--- a/test/test.js
+++ b/test/test.js
@@ -13,16 +13,21 @@ describe( "svg-shield", function ()
         {
             assert.equal( err, null );
             assert.equal( res, '<svg xmlns="http://www.w3.org/2000/svg" width="130" height="20">\n\
-    <mask id="a"><rect width="130" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
-    <g mask="url(#a)">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="130" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
         <path fill="#555" d="M0 0h90v20H0z"/>\n\
         <path fill="#4b1" d="M90 0h60v20H90z"/>\n\
     </g>\n\
     <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="11">\n\
-        <text x="45" y="15" fill="#000"></text>\n\
-        <text x="110" y="15" fill="#000"></text>\n\
-        <text x="45" y="14"></text>\n\
-        <text x="110" y="14"></text>\n\
+        <text x="45" y="14" filter="url(#drop-shadow)"></text>\n\
+        <text x="110" y="14" filter="url(#drop-shadow)"></text>\n\
     </g>\n\
 </svg>' );
 
@@ -40,7 +45,8 @@ describe( "svg-shield", function ()
             name: "name",
             value: "value",
             fontFamily: "Verdana, sans-serif",
-            fontSize: 12
+            fontSize: 12,
+            radius: 7
         };
 
         shield.getShield( options, function ( err, res )
@@ -48,16 +54,21 @@ describe( "svg-shield", function ()
             assert.equal( err, null );
             assert.equal( res,
             '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
-    <mask id="a"><rect width="150" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
-    <g mask="url(#a)">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="150" height="20" rx="7" ry="7" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
         <path fill="#333" d="M0 0h100v20H0z"/>\n\
         <path fill="#000" d="M100 0h60v20H100z"/>\n\
     </g>\n\
     <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="12">\n\
-        <text x="50" y="15" fill="#000">name</text>\n\
-        <text x="125" y="15" fill="#000">value</text>\n\
-        <text x="50" y="14">name</text>\n\
-        <text x="125" y="14">value</text>\n\
+        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
+        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
     </g>\n\
 </svg>' );
 
@@ -83,16 +94,143 @@ describe( "svg-shield", function ()
             assert.equal( err, null );
             assert.equal( res,
             '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
-    <mask id="a"><rect width="150" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
-    <g mask="url(#a)">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="150" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
         <path fill="#333" d="M0 0h100v20H0z"/>\n\
         <path fill="#000" d="M100 0h60v20H100z"/>\n\
     </g>\n\
     <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="17">\n\
-        <text x="50" y="15" fill="#000">name</text>\n\
-        <text x="125" y="15" fill="#000">value</text>\n\
-        <text x="50" y="14">name</text>\n\
-        <text x="125" y="14">value</text>\n\
+        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
+        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    </g>\n\
+</svg>' );
+
+            done();
+        } );
+    } );
+
+    it( "should get a shield with min 8 font-size", function ( done )
+    {
+        var options = {
+            valueWidth: 50,
+            nameWidth: 100,
+            valueBgColor: "#000",
+            nameBgColor: "#333",
+            name: "name",
+            value: "value",
+            fontFamily: "Verdana, sans-serif",
+            fontSize: 4
+        };
+
+        shield.getShield( options, function ( err, res )
+        {
+            assert.equal( err, null );
+            assert.equal( res,
+            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="150" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
+        <path fill="#333" d="M0 0h100v20H0z"/>\n\
+        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+    </g>\n\
+    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="8">\n\
+        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
+        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    </g>\n\
+</svg>' );
+
+            done();
+        } );
+    } );
+
+    it( "should get a shield with min 0 corner radius", function ( done )
+    {
+        var options = {
+            valueWidth: 50,
+            nameWidth: 100,
+            valueBgColor: "#000",
+            nameBgColor: "#333",
+            name: "name",
+            value: "value",
+            fontFamily: "Verdana, sans-serif",
+            fontSize: 12,
+            radius: -6
+        };
+
+        shield.getShield( options, function ( err, res )
+        {
+            assert.equal( err, null );
+            assert.equal( res,
+            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="150" height="20" rx="0" ry="0" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
+        <path fill="#333" d="M0 0h100v20H0z"/>\n\
+        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+    </g>\n\
+    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="12">\n\
+        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
+        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    </g>\n\
+</svg>' );
+
+            done();
+        } );
+    } );
+
+    it( "should get a shield with max 10 corner radius", function ( done )
+    {
+        var options = {
+            valueWidth: 50,
+            nameWidth: 100,
+            valueBgColor: "#000",
+            nameBgColor: "#333",
+            name: "name",
+            value: "value",
+            fontFamily: "Verdana, sans-serif",
+            fontSize: 12,
+            radius: 23
+        };
+
+        shield.getShield( options, function ( err, res )
+        {
+            assert.equal( err, null );
+            assert.equal( res,
+            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+    <defs>\n\
+        <filter id="drop-shadow">\n\
+            <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
+            <feGaussianBlur result="blurOut" in="offOut" stdDeviation="0.5" />\n\
+            <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
+        </filter>\n\
+    </defs>\n\
+    <mask id="round-rect"><rect width="150" height="20" rx="10" ry="10" fill="#fff"/></mask>\n\
+    <g mask="url(#round-rect)">\n\
+        <path fill="#333" d="M0 0h100v20H0z"/>\n\
+        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+    </g>\n\
+    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="12">\n\
+        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
+        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
     </g>\n\
 </svg>' );
 

--- a/test/test.js
+++ b/test/test.js
@@ -79,21 +79,13 @@ describe( "svg-shield", function ()
     it( "should get a shield with max 17 font-size", function ( done )
     {
         var options = {
-            valueWidth: 50,
-            nameWidth: 100,
-            valueBgColor: "#000",
-            nameBgColor: "#333",
-            name: "name",
-            value: "value",
-            fontFamily: "Verdana, sans-serif",
             fontSize: 20
         };
 
         shield.getShield( options, function ( err, res )
         {
             assert.equal( err, null );
-            assert.equal( res,
-            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+            assert.equal( res, '<svg xmlns="http://www.w3.org/2000/svg" width="130" height="20">\n\
     <defs>\n\
         <filter id="drop-shadow">\n\
             <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
@@ -101,14 +93,14 @@ describe( "svg-shield", function ()
             <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
         </filter>\n\
     </defs>\n\
-    <mask id="round-rect"><rect width="150" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
+    <mask id="round-rect"><rect width="130" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
     <g mask="url(#round-rect)">\n\
-        <path fill="#333" d="M0 0h100v20H0z"/>\n\
-        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+        <path fill="#555" d="M0 0h90v20H0z"/>\n\
+        <path fill="#4b1" d="M90 0h60v20H90z"/>\n\
     </g>\n\
-    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="17">\n\
-        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
-        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="17">\n\
+        <text x="45" y="14" filter="url(#drop-shadow)"></text>\n\
+        <text x="110" y="14" filter="url(#drop-shadow)"></text>\n\
     </g>\n\
 </svg>' );
 
@@ -119,21 +111,13 @@ describe( "svg-shield", function ()
     it( "should get a shield with min 8 font-size", function ( done )
     {
         var options = {
-            valueWidth: 50,
-            nameWidth: 100,
-            valueBgColor: "#000",
-            nameBgColor: "#333",
-            name: "name",
-            value: "value",
-            fontFamily: "Verdana, sans-serif",
             fontSize: 4
         };
 
         shield.getShield( options, function ( err, res )
         {
             assert.equal( err, null );
-            assert.equal( res,
-            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+            assert.equal( res, '<svg xmlns="http://www.w3.org/2000/svg" width="130" height="20">\n\
     <defs>\n\
         <filter id="drop-shadow">\n\
             <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
@@ -141,14 +125,14 @@ describe( "svg-shield", function ()
             <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
         </filter>\n\
     </defs>\n\
-    <mask id="round-rect"><rect width="150" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
+    <mask id="round-rect"><rect width="130" height="20" rx="5" ry="5" fill="#fff"/></mask>\n\
     <g mask="url(#round-rect)">\n\
-        <path fill="#333" d="M0 0h100v20H0z"/>\n\
-        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+        <path fill="#555" d="M0 0h90v20H0z"/>\n\
+        <path fill="#4b1" d="M90 0h60v20H90z"/>\n\
     </g>\n\
-    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="8">\n\
-        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
-        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="8">\n\
+        <text x="45" y="14" filter="url(#drop-shadow)"></text>\n\
+        <text x="110" y="14" filter="url(#drop-shadow)"></text>\n\
     </g>\n\
 </svg>' );
 
@@ -159,22 +143,13 @@ describe( "svg-shield", function ()
     it( "should get a shield with min 0 corner radius", function ( done )
     {
         var options = {
-            valueWidth: 50,
-            nameWidth: 100,
-            valueBgColor: "#000",
-            nameBgColor: "#333",
-            name: "name",
-            value: "value",
-            fontFamily: "Verdana, sans-serif",
-            fontSize: 12,
             radius: -6
         };
 
         shield.getShield( options, function ( err, res )
         {
             assert.equal( err, null );
-            assert.equal( res,
-            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+            assert.equal( res, '<svg xmlns="http://www.w3.org/2000/svg" width="130" height="20">\n\
     <defs>\n\
         <filter id="drop-shadow">\n\
             <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
@@ -182,14 +157,14 @@ describe( "svg-shield", function ()
             <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
         </filter>\n\
     </defs>\n\
-    <mask id="round-rect"><rect width="150" height="20" rx="0" ry="0" fill="#fff"/></mask>\n\
+    <mask id="round-rect"><rect width="130" height="20" rx="0" ry="0" fill="#fff"/></mask>\n\
     <g mask="url(#round-rect)">\n\
-        <path fill="#333" d="M0 0h100v20H0z"/>\n\
-        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+        <path fill="#555" d="M0 0h90v20H0z"/>\n\
+        <path fill="#4b1" d="M90 0h60v20H90z"/>\n\
     </g>\n\
-    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="12">\n\
-        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
-        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="11">\n\
+        <text x="45" y="14" filter="url(#drop-shadow)"></text>\n\
+        <text x="110" y="14" filter="url(#drop-shadow)"></text>\n\
     </g>\n\
 </svg>' );
 
@@ -200,22 +175,13 @@ describe( "svg-shield", function ()
     it( "should get a shield with max 10 corner radius", function ( done )
     {
         var options = {
-            valueWidth: 50,
-            nameWidth: 100,
-            valueBgColor: "#000",
-            nameBgColor: "#333",
-            name: "name",
-            value: "value",
-            fontFamily: "Verdana, sans-serif",
-            fontSize: 12,
             radius: 23
         };
 
         shield.getShield( options, function ( err, res )
         {
             assert.equal( err, null );
-            assert.equal( res,
-            '<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">\n\
+            assert.equal( res, '<svg xmlns="http://www.w3.org/2000/svg" width="130" height="20">\n\
     <defs>\n\
         <filter id="drop-shadow">\n\
             <feOffset result="offOut" in="SourceAlpha" dx="0.5" dy="1" />\n\
@@ -223,14 +189,14 @@ describe( "svg-shield", function ()
             <feBlend in="SourceGraphic" in2="blurOut" mode="normal" />\n\
         </filter>\n\
     </defs>\n\
-    <mask id="round-rect"><rect width="150" height="20" rx="10" ry="10" fill="#fff"/></mask>\n\
+    <mask id="round-rect"><rect width="130" height="20" rx="10" ry="10" fill="#fff"/></mask>\n\
     <g mask="url(#round-rect)">\n\
-        <path fill="#333" d="M0 0h100v20H0z"/>\n\
-        <path fill="#000" d="M100 0h60v20H100z"/>\n\
+        <path fill="#555" d="M0 0h90v20H0z"/>\n\
+        <path fill="#4b1" d="M90 0h60v20H90z"/>\n\
     </g>\n\
-    <g fill="#fff" text-anchor="middle" font-family="Verdana, sans-serif" font-size="12">\n\
-        <text x="50" y="14" filter="url(#drop-shadow)">name</text>\n\
-        <text x="125" y="14" filter="url(#drop-shadow)">value</text>\n\
+    <g fill="#fff" text-anchor="middle" font-family="sans-serif" font-size="11">\n\
+        <text x="45" y="14" filter="url(#drop-shadow)"></text>\n\
+        <text x="110" y="14" filter="url(#drop-shadow)"></text>\n\
     </g>\n\
 </svg>' );
 


### PR DESCRIPTION
- Replaced offset text with a proper SVG drop shadow
- Made badge’s corner radius a customizable option with sensible default
- Added sensible min & max for `fontSize` and `radius`
- Updated readme docs
- Updated tests
- Updated examples

@jrit 

With thanks to @dmaloneycalu for suggestion to add a min for `fontSize` & `radius`.
